### PR TITLE
Watch modified on subvaryings

### DIFF
--- a/lib/model/model.js
+++ b/lib/model/model.js
@@ -353,7 +353,7 @@
       isDeep = deep == null ? true : util.isFunction(deep) ? deep(this) : deep === true;
       if (isDeep === true) {
         return (_ref1 = this._watchModifiedDeep$) != null ? _ref1 : this._watchModifiedDeep$ = (function() {
-          var model, result, uniqSubmodels, watchModel, _i, _len, _ref2;
+          var model, result, uniqSubmodels, uniqSubvaryings, varying, watchModel, watchVarying, _i, _j, _len, _len1, _ref2, _ref3;
 
           if (_this._watchModifiedDeep$init === true) {
             return;
@@ -376,17 +376,38 @@
               }
             });
           };
+          watchVarying = function(varying) {
+            var resolveVarying;
+
+            resolveVarying = function(model) {
+              if (model instanceof Model) {
+                _this._subvaryings().remove(varying);
+                _this._submodels().add(model);
+                return varying.off('changed', resolveVarying);
+              }
+            };
+            return varying.react(resolveVarying);
+          };
           uniqSubmodels = _this._submodels().uniq();
+          uniqSubvaryings = _this._subvaryings().uniq();
           _ref2 = uniqSubmodels.list;
           for (_i = 0, _len = _ref2.length; _i < _len; _i++) {
             model = _ref2[_i];
             watchModel(model);
+          }
+          _ref3 = uniqSubvaryings.list;
+          for (_j = 0, _len1 = _ref3.length; _j < _len1; _j++) {
+            varying = _ref3[_j];
+            watchVarying(varying);
           }
           uniqSubmodels.on('added', function(newModel) {
             return watchModel(newModel);
           });
           uniqSubmodels.on('removed', function(oldModel) {
             return result.unlistenTo(oldModel.watchModified(deep));
+          });
+          uniqSubvaryings.on('added', function(newVarying) {
+            return watchVarying(newVarying);
           });
           return result;
         })();
@@ -577,6 +598,12 @@
       if (newValue instanceof Model) {
         this._submodels().add(newValue);
       }
+      if (oldValue instanceof Varying) {
+        this._subvaryings().remove(oldValue);
+      }
+      if (newValue instanceof Varying) {
+        this._subvaryings().add(newValue);
+      }
       emit = function(name, partKey) {
         return _this.emit("" + name + ":" + partKey, newValue, oldValue, partKey);
       };
@@ -593,6 +620,12 @@
       var _ref1;
 
       return (_ref1 = this._submodels$) != null ? _ref1 : this._submodels$ = new (require('../collection/list').List)();
+    };
+
+    Model.prototype._subvaryings = function() {
+      var _ref1;
+
+      return (_ref1 = this._subvaryings$) != null ? _ref1 : this._subvaryings$ = new (require('../collection/list').List)();
     };
 
     return Model;

--- a/src/model/model.coffee
+++ b/src/model/model.coffee
@@ -359,10 +359,22 @@ class Model extends Base
             else
               result.setValue(this.modified(deep))
 
+        # wait for varying to resolve into a model, then stop watching it.
+        watchVarying = (varying) =>
+          resolveVarying = (model) =>
+            if model instanceof Model
+              this._subvaryings().remove(varying)
+              this._submodels().add(model)
+              varying.off('changed', resolveVarying) # stop reacting.
+          varying.react resolveVarying
+
         uniqSubmodels = this._submodels().uniq()
+        uniqSubvaryings = this._subvaryings().uniq()
         watchModel(model) for model in uniqSubmodels.list
-        uniqSubmodels.on('added', (newModel) -> watchModel(newModel))
+        watchVarying(varying) for varying in uniqSubvaryings.list
+        uniqSubmodels.on('added', (newModel) => watchModel(newModel))
         uniqSubmodels.on('removed', (oldModel) -> result.unlistenTo(oldModel.watchModified(deep)))
+        uniqSubvaryings.on('added', (newVarying) => watchVarying(newVarying))
 
         result
 
@@ -515,6 +527,10 @@ class Model extends Base
     this._submodels().remove(oldValue) if oldValue instanceof Model
     this._submodels().add(newValue) if newValue instanceof Model
 
+    # track all our subvaryings.
+    this._subvaryings().remove(oldValue) if oldValue instanceof Varying
+    this._subvaryings().add(newValue) if newValue instanceof Varying
+
     # emit helper.
     emit = (name, partKey) => this.emit("#{name}:#{partKey}", newValue, oldValue, partKey)
 
@@ -531,9 +547,10 @@ class Model extends Base
 
     null
 
-  # Returns the submodel list for this class. Instantiates lazily when
+  # Returns the submodel and subvarying list for this class. Instantiates lazily when
   # requested otherwise we get stack overflow.
   _submodels: -> this._submodels$ ?= new (require('../collection/list').List)()
+  _subvaryings: -> this._subvaryings$ ?= new (require('../collection/list').List)()
 
 
 # Export.

--- a/test/model/model.coffee
+++ b/test/model/model.coffee
@@ -730,3 +730,15 @@ describe 'Model', ->
           shadow.get('test').set('a', 'b')
           evented.should.equal(true)
 
+        it 'should vary when a Reference resolves', ->
+          varying = new Reference()
+          model = new Model( test: varying )
+          shadow = model.shadow()
+
+          expected = [  false, true ]
+          shadow.watchModified().reactNow((isModified) -> isModified.should.equal(expected.shift()))
+
+          submodel = (new Model()).shadow()
+          shadow.get('test').setValue(submodel)
+          submodel.set('testSub', 'y')
+


### PR DESCRIPTION
Some emitted changes pass Varyings (usually References) rather than Models. These need to be watched so that, when resolving, they are also watched by watchModified.

@clint-tseng opinion: should I change all the `subvarying` references to `subreference` instead, since this is really only relevant to References?