### PR TITLE
SEC-157: Adding coffeelint for FEDRAMP purposes

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,5 +38,11 @@
     "grunt-contrib-watch": "~0.4.0",
 
     "grunt-simple-mocha": "~0.4.0"
+  },
+  "coffeelintConfig": {
+    "max_line_length": {
+      "value": 120,
+      "level": "warn"
+    }
   }
 }

--- a/src/janus.coffee.md
+++ b/src/janus.coffee.md
@@ -73,6 +73,23 @@ Installation
 
 Simply install with `npm`: `npm install janus`
 
+Linting
+=======
+
+To install `coffeelint`, run:
+
+```
+npm i -g coffeelint
+```
+
+To run `coffeelint` in the `src` directory, run:
+
+```
+coffeelint src
+```
+
+See `package.json` for the configuration options.
+
 License
 =======
 


### PR DESCRIPTION
This PR sets up coffeescript linting for janus.

- Minimal configuration options for coffeelint were added to `package.json`. Feel free to alter the configuration to suit the project's coding style and increase the signal-to-noise ratio of the output.
- A documentation section was added to README.md.
- Why are we doing this? Fedramp.

Note: A grunt task could be created if desired (using `grunt-coffeelint`), but the linting command is simple enough right now that it wasn't deemed necessary.